### PR TITLE
Add more video & audio codecs to Janus session

### DIFF
--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -735,6 +735,10 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		// Do not use the video-orientation RTP extension as it breaks video
 		// orientation changes in Firefox.
 		"videoorient_ext": false,
+		// Offer more video & audio codecs
+		"audiocodec": "opus,g722,pcmu,pcma,isac32",
+		"videocodec": "vp9,h264,h265,vp8,av1",
+        }
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {


### PR DESCRIPTION
+ change the order of preference. Tested locally, seems to work, at least no error is thrown.